### PR TITLE
Minor fix to prevent error.

### DIFF
--- a/src/CounterCache.php
+++ b/src/CounterCache.php
@@ -23,9 +23,10 @@ trait CounterCache
      * Override update method because we need to listen for relation changes
      *
      * @param array $attributes
+     * @param array $options
      * @return bool
      */
-    public function update(array $attributes = [])
+    public function update(array $attributes = [], array $options = [])
     {
         foreach($this->counterCacheOptions as $method => $counter)
         {


### PR DESCRIPTION
When I installed and configured the plugin, I received the following error:

```
Declaration of kanazaca\CounterCache\CounterCache::update() should be compatible with Illuminate\Database\Eloquent\Model::update(array $attributes = Array, array $options = Array)
```

This PR fixes the error.
